### PR TITLE
build new docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The notebooks in this repository use a ready-to-run Docker image containing Jupy
 
 3. Run the image. Open your terminal and run 
   ```bash
-  $ docker run --user root -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes -e GRANT_SUDO=yes -v "$PWD":/home/jovyan/workspace cartodb/ebook
+  $ docker run --user root -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes -e GRANT_SUDO=yes -v "$PWD":/home/jovyan/workspace cartodb/data-science-book
   ```
 
   A local address will be created. Copy and paste the address in your browser, this will launch Jupyter Lab. **Note**: If you have another Jupyter server running, make sure it's on a different port than 8888. Otherwise change the port number above or close down the other notebook server. 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The notebooks in this repository use a ready-to-run Docker image containing Jupy
 
 1. Clone this repository 
   ```bash
-  $ git clone git@github.com:CartoDB/data-science-book.git`
+  $ git clone git@github.com:CartoDB/data-science-book.git
   $ cd data-science-book
   ```
   

--- a/src_import/modules.R
+++ b/src_import/modules.R
@@ -10,8 +10,7 @@ libraries <- c('devtools',
                'dplyr',
                'mgcv',
                'splancs',
-               'INLA',
-               'INLAutils')
+               'INLA')
 CheckInstallPackages <- function(pkgs){
 
 #For each pkg in pkgs (attempt to load each package one at a time):


### PR DESCRIPTION
Hi @giuliacarella @andy-esch 
- delete a redundant **`** in readme.  
- delete **INLAutils** dependency in `src_import/modules.R`
- push new image `cartodb/ebook` to docker hub (`cartoframes==v1.0.0`)

I've already tested all notebooks but feel free to test them from your side. Also let me know if the new image works and I'll merge this tomorrow. 

Besides, I think we should avoid showing these warning messages. Maybe `warnings.filterwarnings("ignore")`?
 
![Screen Shot 2020-01-22 at 3 04 51 PM](https://user-images.githubusercontent.com/13675438/72929903-c2898500-3d28-11ea-83ff-f20ba7c8190e.png)
